### PR TITLE
Better package description, remove rainbow-mode hack

### DIFF
--- a/aurora-theme.el
+++ b/aurora-theme.el
@@ -1,4 +1,4 @@
-;;; aurora-theme.el --- Material theme of SublimeText for Emacs.
+;;; aurora-theme.el --- A theme inspired by SublimeText's Material theme
 
 ;; Author: Luis Cairampoma <redshacker11@gmail.com>
 ;; URL: http://github.com/xzerocode/aurora-theme
@@ -1020,13 +1020,8 @@ This requires library `rainbow-mode'.")
 
 (provide-theme 'aurora)
 
-;;;###autoload
-(add-to-list 'safe-local-eval-forms
-             '(when (require 'rainbow-mode nil t) (rainbow-mode 1)))
-
 ;; Local Variables:
 ;; no-byte-compile: t
 ;; indent-tabs-mode: nil
-;; eval: (when (require 'rainbow-mode nil t) (rainbow-mode 1))
 ;; End:
 ;;; aurora-theme.el ends here


### PR DESCRIPTION
It's bad practice to modify safe local variables for users without asking them. If you like to use `rainbow-mode`, that's a personal thing, and you can just put something like this in your emacs config like I do:

```el
(defun sanityinc/enable-rainbow-mode-if-theme ()
    (when (string-match "\\(color-theme-\\|-theme\\.el\\)" (buffer-name))
      (rainbow-mode 1)))

(add-hook 'emacs-lisp-mode-hook 'sanityinc/enable-rainbow-mode-if-theme)
```

(In connection with https://github.com/milkypostman/melpa/pull/2999)