### PR TITLE
Made region background higher contrast for easier reading.

### DIFF
--- a/aurora-theme.el
+++ b/aurora-theme.el
@@ -115,7 +115,7 @@ Also bind `class' to ((class color) (min-colors 89))."
      ((t (:foreground ,aurora-green
                       :background ,aurora-bg-05
                       :box (:line-width -1 :style released-button)))))
-   `(region ((,class (:background ,aurora-bg-1))
+   `(region ((,class (:background ,aurora-bg+3))
              (t :inverse-video t)))
    `(secondary-selection ((t (:background ,aurora-bg+2))))
    `(trailing-whitespace ((t (:background ,aurora-red))))


### PR DESCRIPTION
I changed the region (i.e. selection) color to another predefined color to increase the contrast and improve visibility.

Here are the comparisons:

**BEFORE** 
<img width="663" alt="screen shot 2015-08-18 at 12 19 44 am" src="https://cloud.githubusercontent.com/assets/3582299/9324435/10a8db0a-453f-11e5-897a-02b2b29dde0b.png">

**AFTER**
<img width="659" alt="screen shot 2015-08-18 at 12 20 43 am" src="https://cloud.githubusercontent.com/assets/3582299/9324437/1befc44c-453f-11e5-8228-f4b76a0a5340.png">

