### PR TITLE
Change bg color for org checkboxes to aurora-bg+05

### DIFF
--- a/aurora-theme.el
+++ b/aurora-theme.el
@@ -670,7 +670,7 @@ Also bind `class' to ((class color) (min-colors 89))."
    `(org-agenda-structure
      ((t (:inherit font-lock-comment-face))))
    `(org-archived ((t (:foreground ,aurora-fg :weight bold))))
-   `(org-checkbox ((t (:background ,aurora-bg+2 :foreground ,aurora-fg+1
+   `(org-checkbox ((t (:background ,aurora-bg+05 :foreground ,aurora-fg+1
                                    :box (:line-width 1 :style released-button)))))
    `(org-date ((t (:foreground ,aurora-blue :underline t))))
    `(org-deadline-announce ((t (:foreground ,aurora-red))))


### PR DESCRIPTION
With aurora-bg+2, checkbox appear all white. We have to change the background color for checkbox, aurora-bg+05 look decent imo, it highlight the checkbox, is visible, and  suits the background color.

bg+2:
![screen shot 2015-09-04 at 11 47 05 am](https://cloud.githubusercontent.com/assets/1437091/9677797/de564a32-52fb-11e5-8d94-0f0c7f236281.png)

bg+05
![screen shot 2015-09-04 at 11 52 10 am](https://cloud.githubusercontent.com/assets/1437091/9677796/de5316fa-52fb-11e5-95fa-5e0bc1023d25.png)
